### PR TITLE
Only load files in models directory when activating engine

### DIFF
--- a/lib/spree_stock_notifications/engine.rb
+++ b/lib/spree_stock_notifications/engine.rb
@@ -18,7 +18,7 @@ module SpreeStockNotifications
     end
 
     def self.activate
-      Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*.rb')) do |c|
+      Dir.glob(File.join(File.dirname(__FILE__), '../../app/models/**/*.rb')) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
     end


### PR DESCRIPTION
"Activating" all files within the `app` directory is causing an error when the Rails app is reloaded after making a change. Previously the code was only matching files with "decorator" in the name, but this was changed to match all ruby files within the `app` directory. I have narrowed this to only load in all ruby files with the `app/models` directory, so the `StockMailer` class is not reactivated, which was the source of the error.
